### PR TITLE
Fix type check in Lattice_getG

### DIFF
--- a/grcwa/kbloch.py
+++ b/grcwa/kbloch.py
@@ -23,7 +23,9 @@ def Lattice_getG(nG,Lk1,Lk2,method=0):
     
     method:0 for circular truncation, 1 for parallelogramic truncation
     '''
-    assert type(nG) == int, 'nG must be integar'
+    # allow numpy integer types as well as builtin int
+    if not isinstance(nG, (int, np.integer)):
+        raise TypeError('nG must be an integer')
     
     if method == 0:
         G,nG = Gsel_circular(nG, Lk1, Lk2)

--- a/tests/test_kbloch.py
+++ b/tests/test_kbloch.py
@@ -24,6 +24,11 @@ def test_bloch():
     assert nGout>0,'negative nG'
     assert nGout<=nG,'wrong nG'
 
+def test_getG_numpy_int():
+    nG_np = np.int32(50)
+    G2, nGout2 = grcwa.Lattice_getG(nG_np, Lk1, Lk2, method=method)
+    assert nGout2 > 0
+
 if AG_AVAILABLE:
     grcwa.set_backend('autograd')
     Nx = 51


### PR DESCRIPTION
## Summary
- fix integer check in `Lattice_getG`
- test that numpy integer values work

## Testing
- `python -m py_compile grcwa/kbloch.py tests/test_kbloch.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683ff054f9108329a8c3dd4eeb8baf8c