### PR TITLE
Add 1‑D grating support

### DIFF
--- a/example/ex5.py
+++ b/example/ex5.py
@@ -1,0 +1,39 @@
+"""Binary grating example with Ny=1 to demonstrate 1-D support."""
+import grcwa
+import numpy as np
+
+nG = 51
+L1 = [1.0, 0]
+L2 = [0, 1.0]
+freq = 1.0
+theta = 0.0
+phi = 0.0
+
+Nx = 200
+Ny = 1
+
+ep0 = 1.
+epp = 4.
+epbkg = 1.
+
+thick0 = 1.
+thickp = 0.2
+thickN = 1.
+
+# binary grating
+x = np.linspace(0, 1.0, Nx, endpoint=False)
+epgrid = np.ones((Nx, Ny)) * epp
+epgrid[x < 0.5] = epbkg
+
+obj = grcwa.obj(nG, L1, L2, freq, theta, phi, verbose=1)
+obj.Add_LayerUniform(thick0, ep0)
+obj.Add_LayerGrid(thickp, Nx, Ny)
+obj.Add_LayerUniform(thickN, ep0)
+obj.Init_Setup()
+
+planewave = {'p_amp': 1, 's_amp': 0, 'p_phase': 0, 's_phase': 0}
+obj.MakeExcitationPlanewave(planewave['p_amp'], planewave['p_phase'],
+                            planewave['s_amp'], planewave['s_phase'])
+obj.GridLayer_geteps(epgrid.flatten())
+R, T = obj.RT_Solve(normalize=1)
+print('R=', R, 'T=', T, 'R+T=', R + T)

--- a/grcwa/backend.py
+++ b/grcwa/backend.py
@@ -35,6 +35,8 @@ class NumpyBackend():
     outer = staticmethod(np.outer)
     conj = staticmethod(np.conj)
     trace = staticmethod(np.trace)
+    fft = staticmethod(np.fft.fft)
+    ifft = staticmethod(np.fft.ifft)
     fft2 = staticmethod(np.fft.fft2)
     ifft2 = staticmethod(np.fft.ifft2)
 
@@ -75,6 +77,8 @@ if AG_AVAILABLE:
         outer = staticmethod(npa.outer)
         conj = staticmethod(npa.conj)
         trace = staticmethod(npa.trace)
+        fft = staticmethod(npa.fft.fft)
+        ifft = staticmethod(npa.fft.ifft)
         fft2 = staticmethod(npa.fft.fft2)
         ifft2 = staticmethod(npa.fft.ifft2)
 

--- a/grcwa/fft_funs.py
+++ b/grcwa/fft_funs.py
@@ -8,72 +8,122 @@ def Epsilon_fft(dN,eps_grid,G):
                  (2) for anisotropic, a list of numpy 2d array [(Nx,Ny),(Nx,Ny),(Nx,Ny)]
     '''
 
-    if len(eps_grid) == 3 and eps_grid[0].ndim == 2:
-        epsx_fft = get_conv(dN,eps_grid[0],G)
-        epsy_fft = get_conv(dN,eps_grid[1],G)
-        epsz_fft = get_conv(dN,eps_grid[2],G)
+    if isinstance(eps_grid, list):
+        epsx_fft = get_conv(dN, eps_grid[0], G)
+        epsy_fft = get_conv(dN, eps_grid[1], G)
+        epsz_fft = get_conv(dN, eps_grid[2], G)
         epsinv = bd.inv(epsz_fft)
     
         tmp1 = bd.vstack((epsx_fft,bd.zeros_like(epsx_fft)))
         tmp2 = bd.vstack((bd.zeros_like(epsx_fft),epsy_fft))
         eps2 = bd.hstack((tmp1,tmp2))
         
-    elif eps_grid[0].ndim == 1:
-        eps_fft = get_conv(dN,eps_grid,G)
-        epsinv = bd.inv(eps_fft)
-    
-        tmp1 = bd.vstack((eps_fft,bd.zeros_like(eps_fft)))
-        tmp2 = bd.vstack((bd.zeros_like(eps_fft),eps_fft))
-        eps2 = bd.hstack((tmp1,tmp2))
     else:
-        raise ValueError("Wrong eps_grid type")
+        eps_fft = get_conv(dN, eps_grid, G)
+        epsinv = bd.inv(eps_fft)
+
+        tmp1 = bd.vstack((eps_fft, bd.zeros_like(eps_fft)))
+        tmp2 = bd.vstack((bd.zeros_like(eps_fft), eps_fft))
+        eps2 = bd.hstack((tmp1, tmp2))
 
     return epsinv, eps2
     
-def get_conv(dN,s_in,G):
+def _get_conv1d(dN, s_in, G, axis):
+    nG, _ = G.shape
+    sfft = bd.fft(s_in) * dN
+    orders = G[:, axis]
+    ix = range(nG)
+    ii, jj = bd.meshgrid(ix, ix, indexing='ij')
+    N = s_in.shape[0]
+    return sfft[(orders[ii] - orders[jj]) % N]
+
+
+def get_conv(dN, s_in, G):
     ''' Attain convolution matrix
     dN = 1/Nx/Ny
-    s_in: np.array of length Nx*Ny
+    s_in: np.array of length Nx*Ny or Nx or Ny
     G: shape (nG,2), 2 for Lk1,Lk2
     s_out: 1/N sum a_m exp(-2pi i mk/n), shape (nGx*nGy)
     '''
-    nG,_ = G.shape
-    sfft = bd.fft2(s_in)*dN
-    
+    nG, _ = G.shape
 
+    if s_in.ndim == 2 and 1 in s_in.shape:
+        axis = 0 if s_in.shape[1] == 1 else 1
+        vec = s_in[:, 0] if axis == 0 else s_in[0, :]
+        return _get_conv1d(dN, vec, G, axis)
+
+    if s_in.ndim == 1:
+        return _get_conv1d(dN, s_in, G, 0)
+
+    sfft = bd.fft2(s_in) * dN
     ix = range(nG)
-    ii,jj = bd.meshgrid(ix,ix,indexing='ij')
-    s_out = sfft[G[ii,0]-G[jj,0], G[ii,1]-G[jj,1]]    
+    ii, jj = bd.meshgrid(ix, ix, indexing='ij')
+    s_out = sfft[G[ii, 0] - G[jj, 0], G[ii, 1] - G[jj, 1]]
     return s_out
 
-def get_fft(dN,s_in,G):
+def _get_fft1d(dN, s_in, G, axis):
+    sfft = bd.fft(s_in) * dN
+    return sfft[G[:, axis]]
+
+
+def get_fft(dN, s_in, G):
     '''
     FFT to get Fourier components
-    
+
     s_in: np.2d array of size (Nx,Ny)
     G: shape (nG,2), 2 for Gx,Gy
     s_out: 1/N sum a_m exp(-2pi i mk/n), shape (nGx*nGy)
     '''
-    
-    sfft = bd.fft2(s_in)*dN
-    return sfft[G[:,0],G[:,1]]
+
+    if s_in.ndim == 2 and 1 in s_in.shape:
+        axis = 0 if s_in.shape[1] == 1 else 1
+        vec = s_in[:, 0] if axis == 0 else s_in[0, :]
+        return _get_fft1d(dN, vec, G, axis)
+
+    if s_in.ndim == 1:
+        return _get_fft1d(dN, s_in, G, 0)
+
+    sfft = bd.fft2(s_in) * dN
+    return sfft[G[:, 0], G[:, 1]]
 
 
-def get_ifft(Nx,Ny,s_in,G):
+def _get_ifft1d(Nx, Ny, s_in, G, axis):
+    dN = 1.0 / Nx / Ny
+    nG, _ = G.shape
+    N = Nx if axis == 0 else Ny
+    s0 = bd.zeros(N, dtype=complex)
+    orders = G[:, axis]
+    for i in range(nG):
+        stmp = bd.zeros(N, dtype=complex)
+        stmp[orders[i] % N] = 1.0
+        s0 = s0 + s_in[i] * stmp
+    out = bd.ifft(s0) / dN
+    if axis == 0:
+        return out.reshape(Nx, 1)
+    else:
+        return out.reshape(1, Ny)
+
+
+def get_ifft(Nx, Ny, s_in, G):
     '''
     Reconstruct real-space fields
     '''
-    dN = 1./Nx/Ny
-    nG,_ = G.shape
+    if Ny == 1:
+        return _get_ifft1d(Nx, Ny, s_in, G, 0)
+    if Nx == 1:
+        return _get_ifft1d(Nx, Ny, s_in, G, 1)
 
-    s0 = bd.zeros((Nx,Ny),dtype=complex)
+    dN = 1.0 / Nx / Ny
+    nG, _ = G.shape
+
+    s0 = bd.zeros((Nx, Ny), dtype=complex)
     for i in range(nG):
-        x = G[i,0]
-        y = G[i,1]
+        x = G[i, 0]
+        y = G[i, 1]
 
-        stmp = bd.zeros((Nx,Ny),dtype=complex)
-        stmp[x,y] = 1.
-        s0 = s0 + s_in[i]*stmp
+        stmp = bd.zeros((Nx, Ny), dtype=complex)
+        stmp[x, y] = 1.0
+        s0 = s0 + s_in[i] * stmp
 
-    s_out = bd.ifft2(s0)/dN
+    s_out = bd.ifft2(s0) / dN
     return s_out

--- a/grcwa/kbloch.py
+++ b/grcwa/kbloch.py
@@ -27,12 +27,21 @@ def Lattice_getG(nG,Lk1,Lk2,method=0):
     if not isinstance(nG, (int, np.integer)):
         raise TypeError('nG must be an integer')
     
-    if method == 0:
-        G,nG = Gsel_circular(nG, Lk1, Lk2)
-    elif method == 1:
-        G,nG = Gsel_parallelogramic(nG, Lk1, Lk2)
+    if np.linalg.norm(Lk1) == 0 or np.linalg.norm(Lk2) == 0:
+        M = nG // 2
+        orders = np.arange(-M, nG - M)
+        G = np.zeros((nG, 2), dtype=int)
+        if np.linalg.norm(Lk1) != 0:
+            G[:, 0] = orders
+        else:
+            G[:, 1] = orders
     else:
-        raise Exception('Truncation scheme is not included')
+        if method == 0:
+            G, nG = Gsel_circular(nG, Lk1, Lk2)
+        elif method == 1:
+            G, nG = Gsel_parallelogramic(nG, Lk1, Lk2)
+        else:
+            raise Exception('Truncation scheme is not included')
 
     return G,nG
 

--- a/grcwa/rcwa.py
+++ b/grcwa/rcwa.py
@@ -91,6 +91,14 @@ class obj:
 
         # set up reciprocal lattice
         self.Lk1, self.Lk2 = Lattice_Reciprocate(self.L1,self.L2)
+        onedim = False
+        if all(ny == 1 for _, ny in self.GridLayer_Nxy_list):
+            onedim = True
+            self.Lk2 = bd.zeros_like(self.Lk2)
+        elif all(nx == 1 for nx, _ in self.GridLayer_Nxy_list):
+            onedim = True
+            self.Lk1 = bd.zeros_like(self.Lk1)
+
         self.G,self.nG = Lattice_getG(self.nG,self.Lk1,self.Lk2,method=Gmethod)
         
         self.Lk1 = self.Lk1/Pscale
@@ -169,10 +177,23 @@ class obj:
             Ny = self.GridLayer_Nxy_list[ptri][1]
             dN = 1./Nx/Ny
 
-            if len(ep_all) == 3 and ep_all[0].ndim>0:
-                ep_grid = [bd.reshape(ep_all[0][ptr:ptr+Nx*Ny],[Nx,Ny]),bd.reshape(ep_all[1][ptr:ptr+Nx*Ny],[Nx,Ny]),bd.reshape(ep_all[2][ptr:ptr+Nx*Ny],[Nx,Ny])]
+            if len(ep_all) == 3 and ep_all[0].ndim > 0:
+                ep_grid = [bd.reshape(ep_all[0][ptr:ptr + Nx * Ny], [Nx, Ny]),
+                           bd.reshape(ep_all[1][ptr:ptr + Nx * Ny], [Nx, Ny]),
+                           bd.reshape(ep_all[2][ptr:ptr + Nx * Ny], [Nx, Ny])]
             else:
-                ep_grid = bd.reshape(ep_all[ptr:ptr+Nx*Ny],[Nx,Ny])
+                ep_grid = bd.reshape(ep_all[ptr:ptr + Nx * Ny], [Nx, Ny])
+
+            if Ny == 1:
+                if isinstance(ep_grid, list):
+                    ep_grid = [g.reshape(g.shape[0]) for g in ep_grid]
+                else:
+                    ep_grid = ep_grid.reshape(ep_grid.shape[0])
+            elif Nx == 1:
+                if isinstance(ep_grid, list):
+                    ep_grid = [g.reshape(g.shape[1]) for g in ep_grid]
+                else:
+                    ep_grid = ep_grid.reshape(ep_grid.shape[1])
             
             epinv, ep2 = Epsilon_fft(dN,ep_grid,self.G)
 

--- a/tests/test_1d.py
+++ b/tests/test_1d.py
@@ -1,0 +1,36 @@
+import numpy as np
+import grcwa
+
+nG = 51
+L1 = [1.0, 0]
+L2 = [0, 1.0]
+Nx = 101
+Ny = 1
+freq = 1.0
+theta = 0.0
+phi = 0.0
+
+thick0 = 1.0
+thickp = 0.2
+thickN = 1.0
+
+ep0 = 1.0
+epp = 4.0
+epbkg = 1.0
+
+x = np.linspace(0, 1.0, Nx, endpoint=False)
+epgrid = np.ones((Nx, Ny)) * epp
+epgrid[x < 0.5] = epbkg
+
+planewave = {'p_amp': 1, 's_amp': 0, 'p_phase': 0, 's_phase': 0}
+
+def test_binary_grating_1d():
+    obj = grcwa.obj(nG, L1, L2, freq, theta, phi, verbose=0)
+    obj.Add_LayerUniform(thick0, ep0)
+    obj.Add_LayerGrid(thickp, Nx, Ny)
+    obj.Add_LayerUniform(thickN, ep0)
+    obj.Init_Setup()
+    obj.MakeExcitationPlanewave(planewave['p_amp'], planewave['p_phase'],
+                                planewave['s_amp'], planewave['s_phase'])
+    obj.GridLayer_geteps(epgrid.flatten())
+    assert obj.Patterned_epinv_list[0].shape[0] == nG


### PR DESCRIPTION
## Summary
- extend backend with 1‑D FFT helpers
- handle Nx==1 or Ny==1 in FFT utilities
- detect 1‑D patterned layers in `GridLayer_geteps`
- allow 1‑D lattice generation in `Lattice_getG`
- handle 1‑D configurations during initialization
- add binary grating example and regression test

## Testing
- `make test`
- `make lint` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68409f5749f88329a67a91046cd93f6a