### PR TITLE
Cache phi inverses

### DIFF
--- a/tests/test_rcwa.py
+++ b/tests/test_rcwa.py
@@ -88,6 +88,12 @@ def test_rcwa():
     Tx,Ty,Tz = obj.Solve_ZStressTensorIntegral(0)
     assert Tz<0
 
+def test_phi_inv_cache():
+    obj = rcwa_assembly(epgrid,freq,theta,phi,planewave,pthick,Pscale=1.)
+    for l in range(obj.Layer_N):
+        recomputed = np.linalg.inv(obj.phi_list[l])
+        assert np.allclose(obj.phi_inv_list[l], recomputed)
+
 if AG_AVAILABLE:
     grcwa.set_backend('autograd')
     def test_epsgrad():


### PR DESCRIPTION
## Summary
- avoid recomputing phi inverses during scattering matrix assembly
- store layer-wise `phi_inv_list`
- update calls to use cached inverses
- test the cached values

## Testing
- `make lint` *(fails: flake8 not installed)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68409f650eac83298cbd03e105b2342d