### PR TITLE
Add 1D mode and FFT updates

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,7 +12,11 @@ To enable autograd::
 
 To initialize the RCWA::
 
-  obj = grcwa.obj(nG,L1,L2,freq,theta,phi,verbose=0) # verbose=1 for output the actual nG
+  obj = grcwa.obj(nG, L1, L2, freq, theta, phi, verbose=0)
+
+The constructor accepts ``mode='2D'`` by default.  Set ``mode='1D'`` when one
+lattice vector is zero and grid layers use ``Nx=1`` or ``Ny=1`` to model
+1‑D gratings.
 
 To add layers, the order of adding will determine the layer order (1st added layer is 0-th layer, 2nd to be 1st layer, and so forth)::
   

--- a/example/ex1d.py
+++ b/example/ex1d.py
@@ -1,0 +1,50 @@
+"""Demonstrate 1-D binary gratings with Ny=1 and Nx=1."""
+import grcwa
+import numpy as np
+
+nG = 21
+freq = 1.0
+theta = 0.0
+phi = 0.0
+
+planewave = {'p_amp':1,'s_amp':0,'p_phase':0,'s_phase':0}
+
+# Variation along x (Ny=1)
+L1 = [0.5, 0]
+L2 = [0, 0]
+Nx = 40
+Ny = 1
+
+obj = grcwa.obj(nG, L1, L2, freq, theta, phi, verbose=1, mode='1D')
+obj.Add_LayerUniform(1., 1.)
+obj.Add_LayerGrid(0.2, Nx, Ny)
+obj.Add_LayerUniform(1., 1.)
+obj.Init_Setup()
+obj.MakeExcitationPlanewave(**planewave, order=0)
+
+ep = np.ones((Nx, Ny)) * 4.
+mask = np.arange(Nx) < Nx//2
+ep[mask,0] = 1.
+obj.GridLayer_geteps(ep.flatten())
+R, T = obj.RT_Solve(normalize=1)
+print('Ny=1: R=', R, ' T=', T)
+
+# Variation along y (Nx=1)
+L1 = [0, 0]
+L2 = [0, 0.5]
+Nx = 1
+Ny = 40
+
+obj = grcwa.obj(nG, L1, L2, freq, theta, phi, verbose=1, mode='1D')
+obj.Add_LayerUniform(1., 1.)
+obj.Add_LayerGrid(0.2, Nx, Ny)
+obj.Add_LayerUniform(1., 1.)
+obj.Init_Setup()
+obj.MakeExcitationPlanewave(**planewave, order=0)
+
+ep = np.ones((Nx, Ny)) * 4.
+mask = np.arange(Ny) < Ny//2
+ep[0,mask] = 1.
+obj.GridLayer_geteps(ep.flatten())
+R, T = obj.RT_Solve(normalize=1)
+print('Nx=1: R=', R, ' T=', T)

--- a/grcwa/backend.py
+++ b/grcwa/backend.py
@@ -37,6 +37,8 @@ class NumpyBackend():
     trace = staticmethod(np.trace)
     fft2 = staticmethod(np.fft.fft2)
     ifft2 = staticmethod(np.fft.ifft2)
+    fft = staticmethod(np.fft.fft)
+    ifft = staticmethod(np.fft.ifft)
 
     sin = staticmethod(np.sin)
     cos = staticmethod(np.cos)
@@ -77,6 +79,8 @@ if AG_AVAILABLE:
         trace = staticmethod(npa.trace)
         fft2 = staticmethod(npa.fft.fft2)
         ifft2 = staticmethod(npa.fft.ifft2)
+        fft = staticmethod(npa.fft.fft)
+        ifft = staticmethod(npa.fft.ifft)
 
         sin = staticmethod(npa.sin)
         cos = staticmethod(npa.cos)

--- a/tests/test_kbloch.py
+++ b/tests/test_kbloch.py
@@ -99,3 +99,35 @@ if AG_AVAILABLE:
         ref = old_get_conv(dN, s, G)
         grcwa.set_backend('autograd')
         assert np.allclose(ref, new)
+
+    def test_getG_1d():
+        Lk1 = np.array([1.0, 0.0])
+        Lk2 = np.array([0.0, 0.0])
+        G1, n1 = grcwa.Lattice_getG(5, Lk1, Lk2, method=0)
+        assert G1.ndim == 1
+        assert n1 == len(G1)
+        assert G1[0] == -2 and G1[-1] == 2
+
+    def test_fft_1d():
+        N = 16
+        dN1 = 1.0 / N
+        G1 = np.arange(-2, 3)
+        s = np.random.random((N, 1))
+        grcwa.set_backend('numpy')
+        new = grcwa.get_fft(dN1, s, G1)
+        ref = np.fft.fft(s.flatten()) * dN1
+        grcwa.set_backend('autograd')
+        assert np.allclose(ref[G1], new)
+
+    def test_ifft_1d():
+        N = 8
+        dN1 = 1.0 / N
+        G1 = np.arange(-2, 3)
+        x = np.random.random(len(G1))
+        grcwa.set_backend('numpy')
+        new = grcwa.get_ifft(1, N, x, G1)
+        ref_full = np.zeros(N, dtype=complex)
+        ref_full[G1] = x
+        ref = np.fft.ifft(ref_full) / dN1
+        grcwa.set_backend('autograd')
+        assert np.allclose(ref.reshape(1, N), new)


### PR DESCRIPTION
## Summary
- introduce optional `mode` parameter to `rcwa.obj` for choosing 1-D or 2-D operation
- enforce lattice vector and grid size restrictions in 1-D mode
- add 1‑D implementations of `get_conv`, `get_fft` and `get_ifft`
- extend lattice utility functions to generate and use 1‑D `G` sets
- update backend with 1‑D FFT helpers
- document 1‑D usage and add binary grating example
- expand test suite for new functionality

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68557670393883299a4c0ec9c9ff2234